### PR TITLE
[Vercel] Fix Deploy 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites":  [
+      {"source": "/(.*)", "destination": "/"}
+    ]
+}


### PR DESCRIPTION
Added Vercel.json, essentials file to Vercel deploy

I always recommend hosting Nextjs projects on Vercel because of compatibility. It's much more work for when it's something external.